### PR TITLE
API Documentation: Matching ID for ‘Get Subscription’ request and response

### DIFF
--- a/content/subscriptions.md
+++ b/content/subscriptions.md
@@ -31,7 +31,7 @@ Get Subscriptions
 Get Subscription
 ----------------
 
-- `GET /v1/subscriptions/3.json` will return the feed with an id of `3`
+- `GET /v1/subscriptions/525.json` will return the feed with an id of `525`
 
 ```json
 {


### PR DESCRIPTION
Currently the example requests feed `3` and gets back information with the id `525`. Changing the request example so it matches. This also makes the connection between the IDs more clear to the reader.
