### PR TITLE
Clarify subscriptions and entries API

### DIFF
--- a/content/entries.md
+++ b/content/entries.md
@@ -24,6 +24,32 @@ You can get all entries for a user sorted by `created_at` descending. The entry 
 ]
 ```
 
+Note that `title`, `author`, and `content` can be null. For example, using this feed:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <entry>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+  </entry>
+</feed>
+```
+
+```json
+[{
+    "id": 1570169709,
+    "feed_id": 1356310,
+    "title": null,
+    "author": null,
+    "summary": "",
+    "content": null,
+    "url": "http://s3.amazonaws.com",
+    "published": "2017-10-28T14:54:19.885152Z",
+    "created_at":"2017-10-28T14:54:19.885105Z"
+}]
+```
+
 | Parameter                       | Required | Example                                                                                                                                           |
 | ------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `page: number`                  | false    | `GET /v2/entries.json?page=2`  will get page two of the available entries                                                                         |

--- a/content/subscriptions.md
+++ b/content/subscriptions.md
@@ -74,6 +74,28 @@ Create Subscription
 - `404 Not Found` will be returned if no feed is found at the `feed_url`
 - `300 Multiple Choices` will be returned if multiple feeds are found at the `feed_url` 
 
+If `201` or `302` are returned, the response will be the same as **Get Subscription**:
+
+**Request**
+
+```json
+{
+  "feed_url": "http://daringfireball.net/"
+}
+```
+
+**Response**
+
+```json
+{
+    "id": 4105850,
+    "created_at": "2017-10-28T14:30:39.324314Z",
+    "feed_id": 838741,
+    "title": "Daring Fireball",
+    "feed_url": "https://daringfireball.net/feeds/main",
+    "site_url": "https://daringfireball.net/"
+}
+```
 
 If a `300 Multiple Choices` is returned, it means the requested site exposes more than one feed. In this case the response will let you know what the options are. For example:
 


### PR DESCRIPTION
While working on the Feedbin plugin for a desktop reader, I ran into several problems that would have been avoided if the documentation had mentioned it:

 - Unexpected null fields in responses from entries.json (I suspect even more fields are nullable than the ones I listed, but the ones I found are easily reproducable)
 - Had to create a subscription, look in headers, then request the subscription, but after inspecting the requests I realized that creating the subscription was returning all of the subscription data

Fixes #21